### PR TITLE
Vec::remove_item is deprecated, stop using

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msbt"
-version = "0.1.0"
-authors = ["Kyle Clemens <git@kyleclemens.com>"]
+version = "0.1.1"
+authors = ["Anna Clemens <github@annaclemens.io>"]
 edition = "2018"
 
 [dependencies]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -200,7 +200,9 @@ impl MsbtBuilder {
   // }
 
   pub fn nli1(mut self, nli1: Nli1) -> Self {
-    self.section_order.remove_item(&SectionTag::Nli1);
+    if let Some(pos) = self.section_order.iter().position(|x| x == &SectionTag::Nli1) {
+      self.section_order.remove(pos);
+    }
     self.section_order.push(SectionTag::Nli1);
     self.nli1 = Some(nli1);
 
@@ -208,7 +210,9 @@ impl MsbtBuilder {
   }
 
   pub fn ato1(mut self, ato1: Ato1) -> Self {
-    self.section_order.remove_item(&SectionTag::Ato1);
+    if let Some(pos) = self.section_order.iter().position(|x| x == &SectionTag::Ato1) {
+      self.section_order.remove(pos);
+    }
     self.section_order.push(SectionTag::Ato1);
     self.ato1 = Some(ato1);
 
@@ -216,7 +220,9 @@ impl MsbtBuilder {
   }
 
   pub fn atr1(mut self, atr1: Atr1) -> Self {
-    self.section_order.remove_item(&SectionTag::Atr1);
+    if let Some(pos) = self.section_order.iter().position(|x| x == &SectionTag::Atr1) {
+      self.section_order.remove(pos);
+    }
     self.section_order.push(SectionTag::Atr1);
     self.atr1 = Some(atr1);
 
@@ -224,7 +230,9 @@ impl MsbtBuilder {
   }
 
   pub fn tsy1(mut self, tsy1: Tsy1) -> Self {
-    self.section_order.remove_item(&SectionTag::Tsy1);
+    if let Some(pos) = self.section_order.iter().position(|x| x == &SectionTag::Tsy1) {
+      self.section_order.remove(pos);
+    }
     self.section_order.push(SectionTag::Tsy1);
     self.tsy1 = Some(tsy1);
 
@@ -232,7 +240,9 @@ impl MsbtBuilder {
   }
 
   pub fn txt2(mut self, txt2: Txt2) -> Self {
-    self.section_order.remove_item(&SectionTag::Txt2);
+    if let Some(pos) = self.section_order.iter().position(|x| x == &SectionTag::Txt2) {
+      self.section_order.remove(pos);
+    }
     self.section_order.push(SectionTag::Txt2);
     self.txt2 = Some(txt2);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(vec_remove_item)]
-
 use std::{
   boxed::Box,
   collections::BTreeMap,
@@ -707,7 +705,7 @@ pub struct Header {
 }
 
 impl Header {
-  pub fn from_reader(mut reader: &mut Read) -> Result<Self> {
+  pub fn from_reader(mut reader: &mut dyn Read) -> Result<Self> {
     let mut buf = [0u8; 10];
     reader.read_exact(&mut buf[..8]).map_err(Error::Io)?;
 


### PR DESCRIPTION
`remove_item` has been deprecated and will be removed soon. It'd be nice to use `remove` instead.
This also fixes a warning by adding `dyn`.