### PR TITLE
Move from `failure` to `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 
 [dependencies]
 byteordered = "0.4"
-failure = "0.1"
-failure_derive = "0.1"
+thiserror = "1"
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,23 +1,23 @@
-use failure_derive::Fail;
+use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum Error {
-  #[fail(display = "io error: {}", _0)]
+  #[error("io error: {0}")]
   Io(std::io::Error),
-  #[fail(display = "invalid magic bytes")]
+  #[error("invalid magic bytes")]
   InvalidMagic,
-  #[fail(display = "invalid BOM")]
+  #[error("invalid BOM")]
   InvalidBom,
-  #[fail(display = "invalid encoding: {}", _0)]
+  #[error("invalid encoding: {0}")]
   InvalidEncoding(u8),
-  #[fail(display = "invalid utf-8: {}", _0)]
+  #[error("invalid utf-8: {0}")]
   InvalidUtf8(std::string::FromUtf8Error),
-  #[fail(display = "invalid borrowed utf-8: {}", _0)]
+  #[error("invalid borrowed utf-8: {0}")]
   InvalidBorrowedUtf8(std::str::Utf8Error),
-  #[fail(display = "invalid utf-16: {}", _0)]
+  #[error("invalid utf-16: {0}")]
   InvalidUtf16(std::string::FromUtf16Error),
-  #[fail(display = "invalid section header: {:?}", _0)]
+  #[error("invalid section header: {0:?}")]
   InvalidSection([u8; 4]),
 }


### PR DESCRIPTION
I believe `thiserror` is a better fit than `failure` for the crate for the following reasons:

1. Despite being a lighter dependency, it still was pretty much a drop-in replacement for `failure` for your use-case.
2. `failure` is a bit of a mix of domains, while `thiserror` is a better fit for libraries
3. `thiserror` is far more actively maintained

Dependency tree before PR:
```
msbt v0.1.1 (/home/jam/dev/ult/msbt-rs)
├── byteordered v0.4.1
│   └── byteorder v1.3.4
├── failure v0.1.8
│   ├── backtrace v0.3.54
│   │   ├── addr2line v0.14.0
│   │   │   └── gimli v0.23.0
│   │   ├── cfg-if v1.0.0
│   │   ├── libc v0.2.80
│   │   ├── miniz_oxide v0.4.3
│   │   │   └── adler v0.2.3
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.0.1
│   │   ├── object v0.22.0
│   │   └── rustc-demangle v0.1.18
│   └── failure_derive v0.1.8 (proc-macro)
│       ├── proc-macro2 v1.0.24
│       │   └── unicode-xid v0.2.1
│       ├── quote v1.0.7
│       │   └── proc-macro2 v1.0.24 (*)
│       ├── syn v1.0.48
│       │   ├── proc-macro2 v1.0.24 (*)
│       │   ├── quote v1.0.7 (*)
│       │   └── unicode-xid v0.2.1
│       └── synstructure v0.12.4
│           ├── proc-macro2 v1.0.24 (*)
│           ├── quote v1.0.7 (*)
│           ├── syn v1.0.48 (*)
│           └── unicode-xid v0.2.1
└── failure_derive v0.1.8 (proc-macro) (*)
```

Dependency tree after PR:
```
msbt v0.1.1 (/home/jam/dev/ult/msbt-rs)
├── byteordered v0.4.1
│   └── byteorder v1.3.4
└── thiserror v1.0.22
    └── thiserror-impl v1.0.22 (proc-macro)
        ├── proc-macro2 v1.0.24
        │   └── unicode-xid v0.2.1
        ├── quote v1.0.7
        │   └── proc-macro2 v1.0.24 (*)
        └── syn v1.0.48
            ├── proc-macro2 v1.0.24 (*)
            ├── quote v1.0.7 (*)
            └── unicode-xid v0.2.1
```

The biggest thing of note here is a removal of `backtrace` as a dependency, making the library more portable.