### PR TITLE
Fix ATR1 format and padding logic, supporting more games

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -24,6 +24,7 @@ pub struct MsbtBuilder {
   ato1: Option<Ato1>,
   atr1: Option<Atr1>,
   tsy1: Option<Tsy1>,
+  pad_byte: u8,
 }
 
   // macro_rules! add_item {
@@ -90,6 +91,7 @@ impl MsbtBuilder {
       ato1: None,
       atr1: None,
       tsy1: None,
+      pad_byte: 0,
     }
   }
 
@@ -107,6 +109,7 @@ impl MsbtBuilder {
       atr1: self.atr1,
       tsy1: self.tsy1,
       txt2: self.txt2,
+      pad_byte: self.pad_byte,
     };
     let mut pinned_msbt = Box::pin(msbt);
 


### PR DESCRIPTION
This solves issues parsing the following games' MSBTs:
- Animal Crossing: New Horizons
- Mario & Luigi (Superstar Saga and Paper Jam)

Fixes https://github.com/ascclemens/msbt-rs/issues/3

There were 2 issues:
1. ATR1 is a game-specific array of fixed-length byte entries, not strings. ~~Its format is [here](http://kuribo64.net/wiki/?page=MSBT#ATR1_Section).~~
2. Mario & Luigi doesn't use 0xAB for padding, it uses null. Instead of relying on it, we now record what byte was used for padding and then skip to the nearest 0x16 bytes.